### PR TITLE
Add introduction article to schematics

### DIFF
--- a/src/assets/resources.json
+++ b/src/assets/resources.json
@@ -1573,6 +1573,20 @@
         "name": "Ivan Tsymbal",
         "profile": "https://github.com/Poccomaxazt"
       }
+    },
+    {
+      "title": "The Angular CLI at Air France-KLM",
+      "description": "In this article, I will show you what we're doing with the Angular CLI at Air France-KLM, and how the Angular CLI is helping us build better Angular applications.",
+      "author": {
+        "name": "Amadou Sall",
+        "profile": "https://www.amadousall.com/author/amadou/"
+      },
+      "url": "https://www.amadousall.com/the-angular-cli-at-air-france-klm/",
+      "category": "article",
+      "contributor": {
+        "name": "JanMalch",
+        "profile": "https://github.com/JanMalch"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add introduction article to schematics, which shows what problems often arise and how they can be solved with schematics. Also recommends some libraries to be used in every project, like prettier.